### PR TITLE
dont-use-forbidden-chars-in-zip-name

### DIFF
--- a/dtcli/building.py
+++ b/dtcli/building.py
@@ -72,6 +72,10 @@ def _package(
         metadata["name"],
         metadata["version"],
     )
+
+    utils.require_extension_name_valid(extension_file_name)
+    extension_file_name = extension_file_name.replace(":", "_")
+
     extension_file_path = os.path.join(target_dir_path, extension_file_name)
     utils.check_file_exists(extension_file_path)
     try:

--- a/dtcli/utils.py
+++ b/dtcli/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os.path
+import re
 
 
 class ExtensionBuildError(Exception):
@@ -22,6 +23,11 @@ class ExtensionBuildError(Exception):
 class KeyGenerationError(Exception):
     pass
 
+def require_extension_name_valid(extension_name):
+    extension_name_regex = re.compile("^custom:(?!.*(?:\.)$)[0-9a-z-_][0-9a-z-_\.]*$")
+    if not extension_name_regex.match(extension_name):
+        print("%s doesn't satisfy extension naming format, aborting!" % extension_name)
+        raise ExtensionBuildError()
 
 def check_file_exists(file_path, exception_cls=ExtensionBuildError):
     """Returns True and prints a message if file under given path exists and is a real file.

--- a/dtcli/utils.py
+++ b/dtcli/utils.py
@@ -24,7 +24,7 @@ class KeyGenerationError(Exception):
     pass
 
 def require_extension_name_valid(extension_name):
-    extension_name_regex = re.compile("^custom:(?!.*(?:\.)$)[0-9a-z-_][0-9a-z-_\.]*$")
+    extension_name_regex = re.compile("^custom:(?!\\.)(?!.*\\.\\.)(?!.*\\.$)[a-z0-9-_\\.]+$")
     if not extension_name_regex.match(extension_name):
         print("%s doesn't satisfy extension naming format, aborting!" % extension_name)
         raise ExtensionBuildError()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dtcli import utils
+
+def test_require_extension_name_valid():
+    utils.require_extension_name_valid("custom:e")
+    utils.require_extension_name_valid("custom:some.test.ext")
+    utils.require_extension_name_valid("custom:some_simple.test.ext-1")
+    utils.require_extension_name_valid("custom:_some_simple_test_extension")
+    utils.require_extension_name_valid("custom:-some-simple.test.ext_1_")
+
+def test_require_extension_name_valid_negative():
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("some.test.ext")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:.some.test.ext.")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:som:e.t/est.e$xt")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:SOME.test.ext")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:SOME123.test.ext")
+    with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:\u0194test,ext")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,8 @@ def test_require_extension_name_valid_negative():
     with pytest.raises(utils.ExtensionBuildError):
         utils.require_extension_name_valid("custom:.some.test.ext.")
     with pytest.raises(utils.ExtensionBuildError):
+        utils.require_extension_name_valid("custom:some.test..ext")
+    with pytest.raises(utils.ExtensionBuildError):
         utils.require_extension_name_valid("custom:som:e.t/est.e$xt")
     with pytest.raises(utils.ExtensionBuildError):
         utils.require_extension_name_valid("custom:SOME.test.ext")


### PR DESCRIPTION
- zip file is saved as `custom_com.dynatrace.wmi-0.0.1.zip` instead of `custom:com.dynatrace.wmi-0.0.1.zip`
- added extension name verification