### PR TITLE
Add certificate extensions

### DIFF
--- a/dtcli/signing.py
+++ b/dtcli/signing.py
@@ -68,14 +68,32 @@ def generate_ca(ca_cert_file_path, ca_key_file_path, subject, not_valid_after, p
     builder = builder.serial_number(crypto_x509.random_serial_number())
     builder = builder.public_key(public_key)
     builder = builder.add_extension(
-        crypto_x509.BasicConstraints(ca=True, path_length=None),
+        crypto_x509.BasicConstraints(ca=True, path_length=0),
         critical=False,
     )
-    # TODO add aditional extension fields to be on par with openssl result
-    # https://cryptography.io/en/latest/x509/reference.html#cryptography.x509.AuthorityKeyIdentifier
-    # cryptography.x509.AuthorityKeyIdentifier(
-    # https://cryptography.io/en/latest/x509/reference.html#cryptography.x509.SubjectKeyIdentifier
-    # cryptography.x509.SubjectKeyIdentifier
+    subject_identifier = crypto_x509.SubjectKeyIdentifier.from_public_key(public_key)
+    builder = builder.add_extension(
+        subject_identifier,
+        critical=False,
+    )
+    builder = builder.add_extension(
+        crypto_x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(subject_identifier),
+        critical=False,
+    )
+    builder = builder.add_extension(
+        crypto_x509.KeyUsage(
+            digital_signature=False,
+            content_commitment=False,
+            key_encipherment=False,
+            data_encipherment=False,
+            key_agreement=False,
+            key_cert_sign=True,
+            crl_sign=False,
+            encipher_only=False,
+            decipher_only=False
+        ),
+        critical=False,
+    )
     certificate = builder.sign(
         private_key=private_key,
         algorithm=hashes.SHA256(),


### PR DESCRIPTION
The proposed patches set "pathlen=0" on the "basic constraints" extension on CA certificate to prevent signing other certificates with dev certificate. Additionally several new certificate extensions are introduced to limit certificate use for unintended purposes. Sample resulting extensions are presented below.
CA certificate:
```
X509v3 extensions:
    X509v3 Basic Constraints:
        CA:TRUE, pathlen:0
    X509v3 Subject Key Identifier:
        C4:CB:AF:22:7E:9C:08:29:64:E8:C1:F8:80:E3:6B:88:95:14:E6:97
    X509v3 Authority Key Identifier:
        keyid:C4:CB:AF:22:7E:9C:08:29:64:E8:C1:F8:80:E3:6B:88:95:14:E6:97
    X509v3 Key Usage:
        Certificate Sign
```

Dev certificate:
```
X509v3 extensions:
    X509v3 Subject Key Identifier:
        36:66:5D:BF:62:F0:EC:4A:46:C5:A6:BF:9B:AC:94:E3:5E:5E:17:A3
    X509v3 Authority Key Identifier:
        keyid:C4:CB:AF:22:7E:9C:08:29:64:E8:C1:F8:80:E3:6B:88:95:14:E6:97
    X509v3 Key Usage:
        Digital Signature
```
Verified that the generated signatures are successfully verified by both openssl and java