### PR TITLE
Specify python version for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.9
 
 # Install package build system
 RUN pip install poetry


### PR DESCRIPTION
Enforcing python 3.9 as the default changed to 3.10 and is having some troubles with pytest

FIX #51 