### PR TITLE
Use workflow artifacts to store interim docker images

### DIFF
--- a/.github/workflows/built-test-release.yml
+++ b/.github/workflows/built-test-release.yml
@@ -25,10 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Authenticate in GitHub docker registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-
       - name: Pull latest cached docker image
         run: |
           docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:latest || true
@@ -40,9 +36,17 @@ jobs:
             --cache-from docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:latest \
             .
 
-      - name: Push image to GitHub docker registry
+      - name: Export docker image to file
         run: |
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
+          mkdir -p artifacts
+          docker save docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6} > artifacts/image.tar
+        
+      - name: Upload docker image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-image
+          path: |
+            artifacts/image.tar
 
   release-dev-docker-image:
     name: Release development docker image
@@ -59,13 +63,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Download docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
+          path: |
+            artifacts/image.tar
+
+      - name: Load docker image
+        run: |
+          docker load < artifacts/image.tar
+
       - name: Authenticate in GitHub docker registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-
-      - name: Pull latest cached docker image
-        run: |
-          docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
 
       - name: Tag and push image with "latest" tag
         if: github.ref == 'refs/heads/main'
@@ -97,13 +108,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-dev-docker-image
     steps:
-      - name: Authenticate in GitHub docker registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - name: Download docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
+          path: |
+            artifacts/image.tar
 
-      - name: Pull latest cached docker image
+      - name: Load docker image
         run: |
-          docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
+          docker load < artifacts/image.tar
 
       - name: Run pytest tests
         run: |
@@ -139,13 +153,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Authenticate in GitHub docker registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - name: Download docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
+          path: |
+            artifacts/image.tar
 
-      - name: Pull latest cached docker image
+      - name: Load docker image
         run: |
-          docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
+          docker load < artifacts/image.tar
 
       - name: Build package
         run: |
@@ -255,13 +272,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Authenticate in GitHub docker registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - name: Download docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
+          path: |
+            artifacts/image.tar
 
-      - name: Pull latest cached docker image
+      - name: Load docker image
         run: |
-          docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
+          docker load < artifacts/image.tar
 
       - name: Download cached built package
         uses: actions/download-artifact@v2

--- a/.github/workflows/built-test-release.yml
+++ b/.github/workflows/built-test-release.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           name: docker-image
           path: |
-            artifacts/image.tar
+            artifacts
 
       - name: Load docker image
         run: |
@@ -113,7 +113,7 @@ jobs:
         with:
           name: docker-image
           path: |
-            artifacts/image.tar
+            artifacts
 
       - name: Load docker image
         run: |
@@ -158,7 +158,7 @@ jobs:
         with:
           name: docker-image
           path: |
-            artifacts/image.tar
+            artifacts
 
       - name: Load docker image
         run: |
@@ -277,7 +277,7 @@ jobs:
         with:
           name: docker-image
           path: |
-            artifacts/image.tar
+            artifacts
 
       - name: Load docker image
         run: |

--- a/.github/workflows/built-test-release.yml
+++ b/.github/workflows/built-test-release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Load docker image
         run: |
-          docker load < artifacts/image.tar
+          docker load -i artifacts/image.tar
 
       - name: Authenticate in GitHub docker registry
         run: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Load docker image
         run: |
-          docker load < artifacts/image.tar
+          docker load -i artifacts/image.tar
 
       - name: Run pytest tests
         run: |
@@ -162,7 +162,7 @@ jobs:
 
       - name: Load docker image
         run: |
-          docker load < artifacts/image.tar
+          docker load -i artifacts/image.tar
 
       - name: Build package
         run: |
@@ -281,7 +281,7 @@ jobs:
 
       - name: Load docker image
         run: |
-          docker load < artifacts/image.tar
+          docker load -i artifacts/image.tar
 
       - name: Download cached built package
         uses: actions/download-artifact@v2


### PR DESCRIPTION
To accept contributions from forked repositories we may not use docker registry to store interim docker image. The `GITHUB_TOKEN` used to authenticate has only `read` scope for forked repositories. Therefore I'm pushing the interim image to workflow artifacts. 