### PR TITLE
Add --validate option to dt ext upload

### DIFF
--- a/dtcli/scripts/dt.py
+++ b/dtcli/scripts/dt.py
@@ -406,7 +406,9 @@ def validate(**kwargs):
 def upload(**kwargs):
     extension_zip = kwargs['extension_zip']
     require_file_exists(extension_zip)
-    server_api.upload(extension_zip, kwargs['tenant_url'], kwargs['api_token'], kwargs["validate"])
+    if kwargs["validate"]:
+        server_api.validate(extension_zip, kwargs['tenant_url'], kwargs['api_token'])
+    server_api.upload(extension_zip, kwargs['tenant_url'], kwargs['api_token'])
 
 
 

--- a/dtcli/scripts/dt.py
+++ b/dtcli/scripts/dt.py
@@ -400,10 +400,13 @@ def validate(**kwargs):
 @click.option(
     "--api-token", prompt=True, help="Dynatrace API token. Please note that token needs to have the 'Write extension' scope enabled."
 )
+@click.option(
+    "--validate", prompt=True, help="Asks for a validation before uploading the extension", default=False, is_flag=True
+)
 def upload(**kwargs):
     extension_zip = kwargs['extension_zip']
     require_file_exists(extension_zip)
-    server_api.upload(extension_zip, kwargs['tenant_url'], kwargs['api_token'])
+    server_api.upload(extension_zip, kwargs['tenant_url'], kwargs['api_token'], kwargs["validate"])
 
 
 

--- a/dtcli/server_api.py
+++ b/dtcli/server_api.py
@@ -33,7 +33,7 @@ def validate(extension_zip_file, tenant_url, api_token):
             print(f"Extension validation failed!")
             raise dtcliutils.ExtensionValidationError(response.text)
 
-def upload(extension_zip_file, tenant_url, api_token):
+def upload(extension_zip_file, tenant_url, api_token, validate=False):
     url = f"{tenant_url}/api/v2/extensions"
 
     with open(extension_zip_file, "rb") as extzf:
@@ -42,6 +42,9 @@ def upload(extension_zip_file, tenant_url, api_token):
             'Authorization': f'Api-Token {api_token}'
         }
         try:
+            if validate:
+                response = requests.post(url, files={'file': (extension_zip_file, extzf, 'application/zip')}, headers=headers, params={"validateOnly": True})
+                response.raise_for_status()
             response = requests.post(url, files={'file': (extension_zip_file, extzf, 'application/zip')}, headers=headers)
             response.raise_for_status()
             print(f"Extension upload successful!")

--- a/dtcli/server_api.py
+++ b/dtcli/server_api.py
@@ -33,7 +33,7 @@ def validate(extension_zip_file, tenant_url, api_token):
             print(f"Extension validation failed!")
             raise dtcliutils.ExtensionValidationError(response.text)
 
-def upload(extension_zip_file, tenant_url, api_token, validate=False):
+def upload(extension_zip_file, tenant_url, api_token):
     url = f"{tenant_url}/api/v2/extensions"
 
     with open(extension_zip_file, "rb") as extzf:
@@ -42,9 +42,6 @@ def upload(extension_zip_file, tenant_url, api_token, validate=False):
             'Authorization': f'Api-Token {api_token}'
         }
         try:
-            if validate:
-                response = requests.post(url, files={'file': (extension_zip_file, extzf, 'application/zip')}, headers=headers, params={"validateOnly": True})
-                response.raise_for_status()
             response = requests.post(url, files={'file': (extension_zip_file, extzf, 'application/zip')}, headers=headers)
             response.raise_for_status()
             print(f"Extension upload successful!")


### PR DESCRIPTION
Fix #59

When uploading an invalid extension v2 via the API /api/v2/extensions, it returns:
```
{"error":{"code":500,"message":"Internal Server Error occurred. It has been logged and will be investigated."}}
``` 
If we set `validateOnly=true`, it returns:

``` 
{
  "error": {
    "code": 500,
    "message": "Schema validation failed with Exception: 'Nullable property must not have a default value set' for Property 'logLevel' in Schema 'ext:custom:python-rabbitmq'."
  }
}
```

This flag if set, makes a `validateOnly=true` post before uploading the extension, so the developer receives the better error message. This is aligned with how the UI experience works