### PR TITLE
kitson: strip trailing backslash of environment url on extension upload

### DIFF
--- a/dtcli/server_api.py
+++ b/dtcli/server_api.py
@@ -34,6 +34,8 @@ def validate(extension_zip_file, tenant_url, api_token):
             raise dtcliutils.ExtensionValidationError(response.text)
 
 def upload(extension_zip_file, tenant_url, api_token):
+    if tenant_url.endswith("/"):
+        tenant_url = tenant_url[:-1]
     url = f"{tenant_url}/api/v2/extensions"
 
     with open(extension_zip_file, "rb") as extzf:


### PR DESCRIPTION
Closes #61 

Simple check to see if user provided a tenant url with a trailing forward slash. If so it is stripped.

Will avoid confusing cases where a 200 is returned when redirected to a login page when a malformed URL is used resulting in 'success' messages.