### PR TITLE
Add useful development amenities

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use_nix
+PATH_add .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 setup:  ## prepare the environment
 	poetry install
 
+test:
+	poetry run pytest -x
+
 .PHONY: help init
 init: ## one time setup
 	direnv allow .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+setup:  ## prepare the environment
+	poetry install
+
+.PHONY: help init
+init: ## one time setup
+	direnv allow .
+
+help: ## print this message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.DEFAULT_GOAL := help

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+let
+  nixpkgs = builtins.fetchGit {
+    url = "https://github.com/nixos/nixpkgs/";
+    ref = "refs/heads/nixos-unstable";
+    rev = "f2537a505d45c31fe5d9c27ea9829b6f4c4e6ac5"; # 27-06-2022
+    # obtain via `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
+  };
+  pkgs = import nixpkgs { config = {}; };
+  pythonCore = pkgs.python39;
+  myPython = pythonCore.withPackages pythonPkgs;
+  pythonPkgs = python-packages: with python-packages; [
+      poetry
+    ];
+  env = pkgs.buildEnv {
+    name = "dtcli-dev-env";
+    paths =
+    with pkgs;
+    [
+      git
+      gnumake
+      myPython
+      entr
+    ];
+  };
+in
+{
+  shell = pkgs.mkShell {
+    buildInputs = [ env ];
+  };
+}

--- a/dt
+++ b/dt
@@ -1,0 +1,1 @@
+poetry run dt $@


### PR DESCRIPTION
Pinning the Python with nix sets the ground for reproducibility,
Makefile allows for having self-documenting code, instead of a README
and finally direnv and the tiny script is just plain nice.

You can for example have two windows open side-by-side and copy-paste
commands between an environment that has a dt-cli install and a feature
under development. It also abstracts away poetry.