### PR TITLE
Fix missing exit() on a binary

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.2
+current_version = 1.5.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/dtcli/scripts/dt.py
+++ b/dtcli/scripts/dt.py
@@ -789,8 +789,8 @@ def validate_schema(instance, **kwargs):
             print(f'path: {e["path"]}', file=sys.stderr)
             print(f'cause: {e["cause"]}', file=sys.stderr)
     if invalid:
-        print(f"{5* '-'} {i + 1} errors total, aborting! {5* '-'}", file=sys.stderr)
-    exit(invalid)
+        print(f"{30 * '-'}", file=sys.stderr)
+        raise click.ClickException(f"{i + 1} validation errors total, aborting!")
 
 
 @extension_dev.command()

--- a/dtcli/version.py
+++ b/dtcli/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/dynatrace-oss/dt-cli"
-version = "1.5.2"
+version = "1.5.3"
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Apparently exit() does not compile well into the binary, hopefully this
will work