### PR TITLE
Add a is_relative_to shim

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.5
+current_version = 1.6.6
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.github/workflows/built-test-release.yml
+++ b/.github/workflows/built-test-release.yml
@@ -197,6 +197,10 @@ jobs:
                 -p "$(poetry env info -p)/lib/python3.9/site-packages" \
                 --onefile
 
+      - name: Actually run it
+        run: |
+          ./dist/dt
+
       - name: Cache built linux binary artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ ble:
 		-p "$(poetry env info -p)/lib/python3.9/site-packages" \
 		--onefile
 
+ci: lint type-check test
+
 bump-version: ## bumps version (sepecified into VERSION)
 	poetry run bump2version --no-tag --no-commit --new-version $(VERSION) whatever
 

--- a/dtcli/scripts/dt.py
+++ b/dtcli/scripts/dt.py
@@ -34,6 +34,7 @@ from dtcli import server_api
 from dtcli import signing
 from dtcli.click_helpers import deprecated, compose_click_decorators_2, mk_click_callback
 from dtcli.scripts.utility import app as utility_app
+from dtcli.shim import _Path_is_relative
 
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -570,8 +571,8 @@ def build(**kwargs):
     if extension_dir_path == target_dir_path:
         click.echo("Warning: extension_directory is the same as target_directory\n"
                    f"This {click.style('might', bold=True)} cause to include secrets or excessive files", err=True)
-    # TODO: fix properly hotfix with Path
-    elif Path(target_dir_path).is_relative_to(extension_dir_path):
+    # TODO: remove the inner Path call by parsing the argument earlier
+    elif _Path_is_relative(Path(target_dir_path), extension_dir_path):
         click.echo("Warning: target directory contains extension directory \n"
                    f"This {click.style('might', bold=True)} cause to include secrets or excessive files", err=True)
 
@@ -641,7 +642,7 @@ def assemble(source, destination, force):
         raise click.BadParameter(f"destination {destination} already exists, please try again with --force to proceed "
                                  f"irregardless", param_hint="--source")
 
-    if destination.is_relative_to(source):
+    if _Path_is_relative(destination, source):
         click.echo("Warning: source directory contains destination directory\n"
                    f"This {click.style('might', bold=True)} cause to include secrets or excessive files", err=True)
 

--- a/dtcli/shim.py
+++ b/dtcli/shim.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def _Path_is_relative(p: Path, other: Path) -> bool:
+    # TODO: simplify and inline with removal when Python 3.8 is not supported
+    try:
+        return p.is_relative_to(other)
+    # source: https://github.com/python/cpython/blob/3.10/Lib/pathlib.py#L824
+    except AttributeError:  # in Python 3.8
+        try:
+            p.relative_to(*other)
+        except ValueError:
+            return False
+        else:
+            return True

--- a/dtcli/version.py
+++ b/dtcli/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/dynatrace-oss/dt-cli"
-version = "1.6.5"
+version = "1.6.6"
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Python 3.8 doesn't support that feature, and sadly we support Python 3.8

I've tried patching the Path class to keep the nice API, but it was
misbehaving.

Fix #131