### PR TITLE
Remove dtcli-dev builds

### DIFF
--- a/.github/workflows/built-test-release.yml
+++ b/.github/workflows/built-test-release.yml
@@ -59,51 +59,6 @@ jobs:
           docker tag docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:${GITHUB_SHA:0:6} docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:latest
           docker push docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:latest
 
-  release-dev-docker-image:
-    name: Release development docker image
-    #
-    # Releases development image as official development image by tagging
-    # it as "latest".
-    #
-    # Only happens when PR is merged into main or when something is pushed
-    # into main branch.
-    #
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-    needs: build-dev-docker-image
-    steps:
-      - name: Acquire docker environment image
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-          docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:${GITHUB_SHA:0:6}
-
-      - name: Tag and push image with "latest" tag
-        if: github.ref == 'refs/heads/main'
-        run: |
-          docker tag \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:${GITHUB_SHA:0:6} \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
-
-          docker tag \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6} \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:latest
-
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:latest
-
-      - name: Tag and push image with git tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          docker tag \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-env:${GITHUB_SHA:0:6} \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6}
-
-          docker tag \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_SHA:0:6} \
-            docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_REF#refs/tags/}
-
-          docker push docker.pkg.github.com/$GITHUB_REPOSITORY/dtcli-dev:${GITHUB_REF#refs/tags/}
-
   check-line-endings:
     name: Check CRLF line endings
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nobody been using them for the past half a year at least