### PR TITLE
EXT-3708 switch to direct file upload

### DIFF
--- a/dtcli/server_api.py
+++ b/dtcli/server_api.py
@@ -21,11 +21,10 @@ def validate(extension_zip_file, tenant_url, api_token):
     url = f"{tenant_url}/api/v2/extensions?validateOnly=true"
 
     with open(extension_zip_file, "rb") as extzf:
-        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}"}
+        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}",
+                   "Content-Type": "application/octet-stream"}
         try:
-            response = requests.post(
-                url, files={"file": (extension_zip_file, extzf, "application/zip")}, headers=headers
-            )
+            response = requests.post(url, data=extzf, headers=headers)
             response.raise_for_status()
             print("Extension validation successful!")
         except requests.exceptions.HTTPError:
@@ -37,11 +36,10 @@ def upload(extension_zip_file, tenant_url, api_token):
     url = f"{tenant_url}/api/v2/extensions"
 
     with open(extension_zip_file, "rb") as extzf:
-        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}"}
+        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}",
+                   "Content-Type": "application/octet-stream"}
         try:
-            response = requests.post(
-                url, files={"file": (extension_zip_file, extzf, "application/zip")}, headers=headers
-            )
+            response = requests.post(url, data=extzf, headers=headers)
             response.raise_for_status()
             print("Extension upload successful!")
         except requests.exceptions.HTTPError:


### PR DESCRIPTION
Currently extension file is sent using multipart/form-data content type, which was identified to be problematic. As an API consumer you're asked to change POST /v2/extensions request body content type to application/octet-stream. I proposed the changes and tested them locally.