### PR TITLE
Fix error when uploading an extension with 1.264

### DIFF
--- a/dtcli/server_api.py
+++ b/dtcli/server_api.py
@@ -37,7 +37,7 @@ def upload(extension_zip_file, tenant_url, api_token):
     url = f"{tenant_url}/api/v2/extensions"
 
     with open(extension_zip_file, "rb") as extzf:
-        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}"}
+        headers = {"Accept": "application/json; charset=utf-8", "Authorization": f"Api-Token {api_token}", "Content-Type": "application/octet-stream"}
         try:
             response = requests.post(
                 url, files={"file": (extension_zip_file, extzf, "application/zip")}, headers=headers


### PR DESCRIPTION
[Perf Clinic](https://github.com/dynatrace-perfclinics/observability-clinic--unified-analysis/tree/main/extensions-project-starter) does use this code to upload extensions. With DT Version 1.264 a regression was introduced, causing a failure of extension upload. 
