### PR TITLE
Workaround invalid schema metric name regex pattern

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.20
+current_version = 1.6.21
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.19
+current_version = 1.6.20
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ extensions for Dynatrace Extension Framework 2.0.
 <p>
   <a href="https://pypi.org/project/dt-cli/"><img alt="PyPI" src="https://img.shields.io/pypi/v/dt-cli?color=blue&logo=python&logoColor=white"></a>
   <a href="https://pypi.org/project/dt-cli/"><img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/dt-cli?logo=python&logoColor=white"></a>
-  <a href="https://github.com/dynatrace-oss/dt-cli/actions/workflows/built-test-release.yml"><img alt="GitHub Workflow Status (main branch)" src="https://img.shields.io/github/actions/workflow/status/dynatrace-oss/dt-cli/test.yml?branch=main&logo=github"></a>
+  <a href="https://github.com/dynatrace-oss/dt-cli/actions/workflows/test.yml"><img alt="GitHub Workflow Status (main branch)" src="https://img.shields.io/github/actions/workflow/status/dynatrace-oss/dt-cli/test.yml?branch=main&logo=github"></a>
 </p>
 
 ## Features

--- a/dtcli/scripts/dt.py
+++ b/dtcli/scripts/dt.py
@@ -20,6 +20,7 @@ import platform
 import re
 import sys
 from pathlib import Path
+from pprint import pprint
 
 import click
 import requests  # noqa:I201
@@ -838,8 +839,9 @@ def delete(**kwargs):
 )
 def validate_schema(instance, **kwargs):
     errors = _validate_schema.validate_schema(
-        instance_object=instance, schema_entrypoint=kwargs["schema_entrypoint"],
-        warn=functools.partial(click.echo, err=True))
+        extension_yaml_path=instance, extension_schema_path=kwargs["schema_entrypoint"],
+        warn=functools.partial(click.echo, err=True),
+    )
     invalid = False
     if errors:
         invalid = True
@@ -847,7 +849,11 @@ def validate_schema(instance, **kwargs):
             print(f'{10 * "-"} error {i} {10 * "-"}', file=sys.stderr)
             print(f'line: {e["line"]}, column: {e["column"]}', file=sys.stderr)
             print(f'path: {e["path"]}', file=sys.stderr)
-            print(f'cause: {e["cause"]}', file=sys.stderr)
+            cause = e["cause"]
+            if isinstance(cause, dict):
+                pprint(f'cause: {cause}', stream=sys.stderr)
+            else:
+                print(f'cause: {e["cause"]}', file=sys.stderr)
     if invalid:
         print(f"{30 * '-'}", file=sys.stderr)
         raise click.ClickException(f"{i + 1} validation errors total, aborting!")

--- a/dtcli/validate_schema.py
+++ b/dtcli/validate_schema.py
@@ -3,9 +3,11 @@ import pathlib
 from pathlib import Path
 from typing import Any, List, Union, Callable
 
-import yaml
-from referencing import Registry, Resource
 from jsonschema import Draft202012Validator, Validator, ValidationError
+
+from referencing import Registry, Resource
+
+import yaml
 
 
 YamlAST = Union[yaml.ScalarNode, yaml.SequenceNode, yaml.MappingNode]

--- a/dtcli/version.py
+++ b/dtcli/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.6.20"
+__version__ = "1.6.21"

--- a/dtcli/version.py
+++ b/dtcli/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.6.19"
+__version__ = "1.6.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/dynatrace-oss/dt-cli"
-version = "1.6.19"
+version = "1.6.20"
 
 [tool.poetry.dependencies]
 PyYAML = "^6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/dynatrace-oss/dt-cli"
-version = "1.6.20"
+version = "1.6.21"
 
 [tool.poetry.dependencies]
 PyYAML = "^6.0"


### PR DESCRIPTION
# Summary

Fixes #178 

## What's done

1. Migrated off deprecated `jsonschema` `RefResolver`.
2. Ignore invalid regex pattern during schema validation. Still check everything else.

## Testing

Normal extension written with schema 1.291 in mind

```shell
dt-cli on  dev [!⇕] is 📦 v1.6.20 via 🐍 v3.10.13 (.venv) 
❯ ./.venv/bin/dt ext validate-schema --instance ~/Projects/Extensions/python-fortigate/extension/extension.yaml --schema-entrypoint schemas/1.295.0/extension.schema.json

dt-cli on  dev [!⇕] is 📦 v1.6.20 via 🐍 v3.10.13 (.venv) took 3s 
❯ ./.venv/bin/dt ext validate-schema --instance ~/Projects/Extensions/python-fortigate/extension/extension.yaml --schema-entrypoint schemas/1.304.0/extension.schema.json
```

Latest extension written using schema 1.304

```shell
dt-cli on  dev [!⇕] is 📦 v1.6.20 via 🐍 v3.10.13 (.venv) 
❯ ./.venv/bin/dt ext validate-schema --instance ~/Projects/Extensions/otel-collector-prometheus-postgres/src/extension/extension.yaml --schema-entrypoint schemas/1.304.0/extension.schema.json
```

Purposefully introduced a mistake in the `extension.yaml` to see if validation still works

```shell
dt-cli on  dev [!⇕] is 📦 v1.6.20 via 🐍 v3.10.13 (.venv) took 5s 
❯ ./.venv/bin/dt ext validate-schema --instance ~/Projects/Extensions/otel-collector-prometheus-postgres/src/extension/extension.yaml --schema-entrypoint schemas/1.304.0/extension.schema.json
---------- error 0 ----------
line: 0, column: 0
path: 
cause: 'minDynatraceVersion' is a required property
---------- error 1 ----------
line: 0, column: 0
path: 
cause: Additional properties are not allowed ('minDynatraceVersions' was unexpected)
------------------------------
Error: 2 validation errors total, aborting!
```